### PR TITLE
Doc: Enhance contributors info adds korean translate

### DIFF
--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -28,7 +28,7 @@ Pull Request를 열 줄 모르신다면, Issues에 올리셔도 괜찮습니다.
 - 공식 다운로드 페이지 ([Korean](https://telk.kr/ottd/newgrf/ko_train_set/?lang=kr) / [English](https://telk.kr/ottd/newgrf/ko_train_set/?lang=en) / [Japanese](https://telk.kr/ottd/newgrf/ko_train_set/?lang=jp) / [Spanish](https://telk.kr/ottd/newgrf/ko_train_set/?lang=es))
 
 ## 기여하신 분들
-모든 기여하신 분들의 이름은 [contributors.md](https://github.com/KoreanGRF/KoreanTrainSet/blob/main/docs/contributors.md)에서 볼 수 있습니다.
+모든 기여하신 분들의 이름은 [contributors.md](https://github.com/KoreanGRF/KoreanTrainSet/blob/main/docs/contributors.ko.md)에서 볼 수 있습니다.
 
 ## 라이선스
 이 NewGRF는 **[크리에이티브 커먼스 라이선스 v3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/)** (CC-BY-NC-SA v3.0)을 따릅니다.  

--- a/docs/contributors.ko.md
+++ b/docs/contributors.ko.md
@@ -19,4 +19,4 @@
 ## 번역에 기여하신 분
   * 한국어, 영어 (영국, 미국), 일본어: [@telk5093](https://github.com/telk5093)
 
-  그래픽 기여와 관련된 자세한 사항에 대해서는  [contributors_graphic.md](./contributors_graphic.md)에서 볼수 있습니다.
+  그래픽 기여와 관련된 자세한 사항에 대해서는  [contributors_graphic.md](./contributors_graphic.md)에서 확인 하실수 있습니다.

--- a/docs/contributors.ko.md
+++ b/docs/contributors.ko.md
@@ -1,0 +1,22 @@
+ # 기여하신 분들
+## **코드에 기여하신 분**
+  * **TELK** ([@telk5093](https://github.com/telk5093), telk5093@gmail.com, http://telk.kr) - Major NML Code and graphic modifications
+
+## **그래픽에 기여하신 분들**
+  * **skyu** (skyu2947@gmail.com) - 주요 그래픽
+  * **라스(Las)** (wlq10000@naver.com)
+  * **작가(Jakga)** (angryphw@naver.com)
+  * **초저항(Chojeohang)** (yunggu7410@naver.com) - 부산 4호선 선로 및 차량
+  * **오픈기차(Opentrain)** ([@opentrain](https://github.com/opentrain), gks3900@naver.com)
+  * **kiwitree** ([@kiwitreekor](https://github.com/kiwitreekor))
+  * **Nebula** ([@SerpensNebula](https://github.com/SerpensNebula)) - 증기 기관차 차량
+  * **즉삭** ([@ChuoSpecialRapid201](https://github.com/ChuoSpecialRapid201))
+  * **kimgas** ([@kimgas](https://github.com/kimgas))
+  * **EightonEight** ([@EightonEight](https://github.com/EightonEight))
+  * **JukjeonWani** ([@JukjeonWani](https://github.com/JukjeonWani))
+  * **Coconut** ([@Coconut](https://github.com/CoconutKR))
+
+## 번역에 기여하신 분
+  * 한국어, 영어 (영국, 미국), 일본어: [@telk5093](https://github.com/telk5093)
+
+  그래픽 기여와 관련된 자세한 사항에 대해서는  [contributors_graphic.md](./contributors_graphic.md)에서 볼수 있습니다.


### PR DESCRIPTION
`Contributors.md` 를 한글화 하고 `README.ko.md` 에서 기여하신 분들 클릭 시 한글화된 `contributors.ko.md` 를 표시하도록 변경함.
영어 `README.md`에서 `contributors.md` 클릭시 기존과 동일하게 영어로 표시됨