### PR TITLE
Update EEC, DEC, NDC livery names changed

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -237,18 +237,18 @@ STR_REFIT_LIVERY_SLEEPING_1977_YELLOW_RED                  : (1977 livery: Yello
 STR_REFIT_LIVERY_SLEEPING_2001_YELLOW_RED                  : (2001 livery: Yellow & Red)
 
 # Refit (NDC)
-STR_REFIT_LIVERY_NDC_1                                     : (Livery: 1984~1994)
-STR_REFIT_LIVERY_NDC_2                                     : (Livery: 1994~2009)
+STR_REFIT_LIVERY_NDC_1                                     : (Livery: 1984~1994 : Mugunghwa)
+STR_REFIT_LIVERY_NDC_2                                     : (Livery: 1994~2009 : Mugunghwa)
 STR_REFIT_LIVERY_NDC_BUSINESS                              : (Business car)
 
 # Refit (DEC)
 STR_REFIT_LIVERY_DEC_1                                     : (Livery: 1980~1986 : Saemaeul)
-STR_REFIT_LIVERY_DEC_2                                     : (Livery: 1986~1994)
-STR_REFIT_LIVERY_DEC_3                                     : (Livery: 1994~1999)
+STR_REFIT_LIVERY_DEC_2                                     : (Livery: 1986~1994 : Mugunghwa)
+STR_REFIT_LIVERY_DEC_3                                     : (Livery: 1994~1999 : Mugunghwa)
 
 # Refit (EEC)
-STR_REFIT_LIVERY_EEC_1                                     : (Livery: 1980~1994)
-STR_REFIT_LIVERY_EEC_2                                     : (Livery: 1994~1998)
+STR_REFIT_LIVERY_EEC_1                                     : (Livery: 1980~1994 : Mugumghwa)
+STR_REFIT_LIVERY_EEC_2                                     : (Livery: 1994~1998 : Mugunghwa)
 STR_REFIT_LIVERY_EEC_3                                     : (Livery: 1998~2001 : Tongil)
 
 # Refit (Mail car)

--- a/lang/japanese.lng
+++ b/lang/japanese.lng
@@ -236,18 +236,18 @@ STR_REFIT_LIVERY_SLEEPING_1977_YELLOW_RED                  :(1977年：黄色＆
 STR_REFIT_LIVERY_SLEEPING_2001_YELLOW_RED                  :(2001年：黄色＆赤色)
 
 # Refit (NDC)
-STR_REFIT_LIVERY_NDC_1                                     :(1984~1994年塗色)
-STR_REFIT_LIVERY_NDC_2                                     :(1994~2009年塗色)
+STR_REFIT_LIVERY_NDC_1                                     :(1984~1994年塗色:ムグンファ号)
+STR_REFIT_LIVERY_NDC_2                                     :(1994~2009年塗色:ムグンファ号)
 STR_REFIT_LIVERY_NDC_BUSINESS                              :(ビジネス動車)
 
 # Refit (DEC)
-STR_REFIT_LIVERY_DEC_1                                     :(1980~1986年塗色：セマウル号)
-STR_REFIT_LIVERY_DEC_2                                     :(1986~1994年塗色)
-STR_REFIT_LIVERY_DEC_3                                     :(1994~1999年塗色)
+STR_REFIT_LIVERY_DEC_1                                     :(1980~1986年塗色:セマウル号)
+STR_REFIT_LIVERY_DEC_2                                     :(1986~1994年塗色:ムグンファ号)
+STR_REFIT_LIVERY_DEC_3                                     :(1994~1999年塗色:ムグンファ号)
 
 # Refit (EEC)
-STR_REFIT_LIVERY_EEC_1                                     :(1980~1994年塗色)
-STR_REFIT_LIVERY_EEC_2                                     :(1994~1998年塗色)
+STR_REFIT_LIVERY_EEC_1                                     :(1980~1994年塗色:ムグンファ号)
+STR_REFIT_LIVERY_EEC_2                                     :(1994~1998年塗色:ムグンファ号)
 STR_REFIT_LIVERY_EEC_3                                     :(1998~2001年塗色：トンイル号)
 
 # Refit (Mail car)

--- a/lang/korean.lng
+++ b/lang/korean.lng
@@ -237,18 +237,18 @@ STR_REFIT_LIVERY_SLEEPING_1977_YELLOW_RED                  : (1977년: 노랑 & 
 STR_REFIT_LIVERY_SLEEPING_2001_YELLOW_RED                  : (2001년: 노랑 & 빨강)
 
 # Refit (NDC)
-STR_REFIT_LIVERY_NDC_1                                     : (1984~1994년 도색)
-STR_REFIT_LIVERY_NDC_2                                     : (1994~2009년 도색)
+STR_REFIT_LIVERY_NDC_1                                     : (1984~1994년 도색 : 무궁화호)
+STR_REFIT_LIVERY_NDC_2                                     : (1994~2009년 도색 : 무궁화호)
 STR_REFIT_LIVERY_NDC_BUSINESS                              : (비즈니스 동차)
 
 # Refit (DEC)
 STR_REFIT_LIVERY_DEC_1                                     : (1980~1986년 도색 : 새마을호)
-STR_REFIT_LIVERY_DEC_2                                     : (1986~1994년 도색)
-STR_REFIT_LIVERY_DEC_3                                     : (1994~1999년 도색)
+STR_REFIT_LIVERY_DEC_2                                     : (1986~1994년 도색 : 무궁화호)
+STR_REFIT_LIVERY_DEC_3                                     : (1994~1999년 도색 : 무궁화호)
 
 # Refit (EEC)
-STR_REFIT_LIVERY_EEC_1                                     : (1980~1994년 도색)
-STR_REFIT_LIVERY_EEC_2                                     : (1994~1998년 도색)
+STR_REFIT_LIVERY_EEC_1                                     : (1980~1994년 도색 : 우등 & 무궁화호)
+STR_REFIT_LIVERY_EEC_2                                     : (1994~1998년 도색 : 무궁화호)
 STR_REFIT_LIVERY_EEC_3                                     : (1998~2001년 도색 : 통일호)
 
 # Refit (Mail car)


### PR DESCRIPTION
Update EEC, DEC, NDC livery names changed
우등형 전기동차, 우등형 디젤 전기동차, 우등형 디젤액압동차 3종의 차량에 대해 일부 도색에만 등급명을 병기한것을 다른 도색에도 추가하여 3종의 차량 모든 도색에 대한 등급명을 알수 있게함.