### PR TITLE
Doc: Enhance contributors info

### DIFF
--- a/docs/contributors_graphic.md
+++ b/docs/contributors_graphic.md
@@ -1,229 +1,236 @@
-Based in Korean Train Set 2.5.1+ ([039487c](https://github.com/KoreanGRF/KoreanTrainSet/commit/039487c45494e07ed37385db1a136272a4b5c7c7))
+This page shows that who is the author of graphic sprites of each vehicles, especially when we didn't used the version controlling via git.  
+There's no need to add or edit this page since git stores every author's information unless there is no information in the table below.  
+  
+Page version: based on 2.6.1 ([5ffec9d](https://github.com/KoreanGRF/KoreanTrainSet/commit/5ffec9d6a8eb1f7d502e600af17f95b925552ce0))
 
 ## sample
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``U100_by_TELK`` | [@telk5093](https://github.com/telk5093) | This is a sample row, this graphic is not used. |
+| Code 			| Author (legacy) 	| Author (standard) 	| Reference |
+|-----------------------|-----------------------|-----------------------|-----------|
+| ``U100_by_TELK`` 	| @telk5093 		| 			| This is a sample row, this graphic is not used. |
 
-## locomotive
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``BIDULGI_CDC`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#40](https://github.com/KoreanGRF/KoreanTrainSet/issues/40) |
-| ``CDC`` | skyu, [@telk5093](https://github.com/telk5093), [@opentrain](https://github.com/opentrain) | |
-| ``DEC`` | [@kiwitreekor](https://github.com/kiwitreekor), [@kimgas](https://github.com/kimgas) | [#15](https://github.com/KoreanGRF/KoreanTrainSet/issues/15) |
-| ``ECOBEE`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#38](https://github.com/KoreanGRF/KoreanTrainSet/issues/38) |
-| ``EEC`` | [@kiwitreekor](https://github.com/kiwitreekor), [@kimgas](https://github.com/kimgas) | [#15](https://github.com/KoreanGRF/KoreanTrainSet/issues/15) |
-| ``K2x00`` | [@opentrain](https://github.com/opentrain) | [#90](https://github.com/KoreanGRF/KoreanTrainSet/issues/90) |
-| ``K4x00`` | Original: unknown<br />Las | <https://cafe.naver.com/ottd/10534> |
-| V-train and its wagons | Las<br />Modified by [@EightonEight](https://github.com/EightonEight) | <https://cafe.naver.com/ottd/10466><br />modified: [#390](https://github.com/KoreanGRF/KoreanTrainSet/pull/390) |
-| ``K5000`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@SerpensNebula](https://github.com/SerpensNebula) | [#176](https://github.com/KoreanGRF/KoreanTrainSet/issues/176)<br />modified: [#352](https://github.com/KoreanGRF/KoreanTrainSet/issues/352) |
-| ``K6x00`` | [@kiwitreekor](https://github.com/kiwitreekor), [@SerpensNebula](https://github.com/SerpensNebula) | [#176](https://github.com/KoreanGRF/KoreanTrainSet/issues/176), [#250](https://github.com/KoreanGRF/KoreanTrainSet/issues/250)<br />modified: [#352](https://github.com/KoreanGRF/KoreanTrainSet/issues/352) |
-| Kwankwang-ho and its wagons | [@SerpensNebula](https://github.com/SerpensNebula) | [#241](https://github.com/KoreanGRF/KoreanTrainSet/issues/241) |
-| ``K7000`` | Modified by Las, [@SerpensNebula](https://github.com/SerpensNebula) | <https://cafe.naver.com/ottd/10534>, [#353](https://github.com/KoreanGRF/KoreanTrainSet/issues/353) |
-| ``K7x00`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@SerpensNebula](https://github.com/SerpensNebula), [@JukjeonWani](https://github.com/JukjeonWani) | modified: [#351](https://github.com/KoreanGRF/KoreanTrainSet/issues/351), [#360](https://github.com/KoreanGRF/KoreanTrainSet/issues/360) |
-| G-train and its wagons | [@opentrain](https://github.com/opentrain)<br />Modified by [@telk5093](https://github.com/telk5093), [@JukjeonWani](https://github.com/JukjeonWani) | <https://cafe.naver.com/ottd/10464><br />modified: [#127](https://github.com/KoreanGRF/KoreanTrainSet/issues/127), [#223](https://github.com/KoreanGRF/KoreanTrainSet/issues/223), [#361](https://github.com/KoreanGRF/KoreanTrainSet/issues/361), [#387](https://github.com/KoreanGRF/KoreanTrainSet/issues/387) |
-| Haerang and its wagons | Las?<br />Modified by [@JukjeonWani](https://github.com/JukjeonWani) | modified: [#361](https://github.com/KoreanGRF/KoreanTrainSet/issues/361) |
-| S-train and its wagons | Las<br />Modified by [@JukjeonWani](https://github.com/JukjeonWani) | <https://cafe.naver.com/ottd/10466><br />modified: [#361](https://github.com/KoreanGRF/KoreanTrainSet/issues/361) |
-| ``K7600`` | skyu | |
-| A-train and its wagons | [@kiwitreekor](https://github.com/kiwitreekor), [@kimgas](https://github.com/kimgas)<br />Modified by [@JukjeonWani](https://github.com/JukjeonWani) | [#15](https://github.com/KoreanGRF/KoreanTrainSet/issues/15)<br />modified: [#361](https://github.com/KoreanGRF/KoreanTrainSet/issues/361) |
-| ``K8000`` | skyu | |
-| ``K8x00`` | skyu<br />Modified by [@SerpensNebula](https://github.com/SerpensNebula) | modified: [#359](https://github.com/KoreanGRF/KoreanTrainSet/issues/359) |
-| ``K8500`` | skyu<br />Modified by [@SerpensNebula](https://github.com/SerpensNebula) | modified: [#359](https://github.com/KoreanGRF/KoreanTrainSet/issues/359) |
-| ``EUM`` | skyu<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#370](https://github.com/KoreanGRF/KoreanTrainSet/pull/370), [#376](https://github.com/KoreanGRF/KoreanTrainSet/pull/376) |
-| ``EUM_32bpp`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight) | [#319](https://github.com/KoreanGRF/KoreanTrainSet/issues/319), [#320](https://github.com/KoreanGRF/KoreanTrainSet/issues/320)<br />modified: [#370](https://github.com/KoreanGRF/KoreanTrainSet/pull/370), [#376](https://github.com/KoreanGRF/KoreanTrainSet/pull/376) |
-| KTX-EUM 320 wagon | [@EightonEight](https://github.com/EightonEight) | [#368](https://github.com/KoreanGRF/KoreanTrainSet/issues/368) |
-| ``KTX1N`` | skyu | |
-| ``KTX2N`` | Las<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#376](https://github.com/KoreanGRF/KoreanTrainSet/pull/376), [#377](https://github.com/KoreanGRF/KoreanTrainSet/pull/377) |
-| ``KTX2N_PYEONGCHANG`` | RIPper<br />Modified by [@EightonEight](https://github.com/EightonEight) | [#89](https://github.com/KoreanGRF/KoreanTrainSet/issues/89)<br />modified: [#376](https://github.com/KoreanGRF/KoreanTrainSet/pull/376), [#377](https://github.com/KoreanGRF/KoreanTrainSet/pull/377) |
-| ``SRT`` | Las<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#377](https://github.com/KoreanGRF/KoreanTrainSet/pull/377) |
-| ``SRT_32bpp`` | [@EightonEight](https://github.com/EightonEight) | [#377](https://github.com/KoreanGRF/KoreanTrainSet/pull/377) |
-| ``NDC`` | Original: unknown<br />Modified by [@telk5093](https://github.com/telk5093) (Business car)<br />Modified by [@kiwitreekor](https://github.com/kiwitreekor) (Width of horizontal sprites) | modified: [#15](https://github.com/KoreanGRF/KoreanTrainSet/issues/15) |
-| ``NURIRO`` | [@telk5093](https://github.com/telk5093)<br />(original: ``ITX_CHEONGCHUN``)<br />Modified by [@kimgas](https://github.com/kimgas), [@EightonEight](https://github.com/EightonEight) (New livery) | modified: [#140](https://github.com/KoreanGRF/KoreanTrainSet/issues/140), [#362](https://github.com/KoreanGRF/KoreanTrainSet/issues/362) |
-| ``NURIRO_SANTA`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@kimgas](https://github.com/kimgas) | [#106](https://github.com/KoreanGRF/KoreanTrainSet/issues/106)<br />modified: [#140](https://github.com/KoreanGRF/KoreanTrainSet/issues/140) |
-| ``DHC`` | skyu<br />modified by [@telk5093](https://github.com/telk5093) | modified: [#34](https://github.com/KoreanGRF/KoreanTrainSet/issues/34) |
-| ``ITX-saemaeul`` | Las<br />Modified by [@EightonEight](https://github.com/EightonEight) | <https://cafe.naver.com/ottd/7468><br />modified: [#376](https://github.com/KoreanGRF/KoreanTrainSet/pull/376) |
-| ``MIKA3`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#37](https://github.com/KoreanGRF/KoreanTrainSet/issues/37)<br />modified: [#276](https://github.com/KoreanGRF/KoreanTrainSet/issues/276) |
-| ``PASHI5`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#37](https://github.com/KoreanGRF/KoreanTrainSet/issues/37)<br />modified: [#276](https://github.com/KoreanGRF/KoreanTrainSet/issues/276) |
-| ``MATE2`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#37](https://github.com/KoreanGRF/KoreanTrainSet/issues/37)<br />modified: [#276](https://github.com/KoreanGRF/KoreanTrainSet/issues/276) |
+## train
+### locomotive
+| Code 				| Author (legacy) 										| Author (standard) 					| Reference |
+|-------------------------------|-----------------------------------------------------------------------------------------------|-------------------------------------------------------|-----------|
+| ``BIDULGI_CDC`` 		| @SerpensNebula 										| @SerpensNebula 					| #40<br />template changed: #432 |
+| ``CDC`` 			| skyu, @telk5093, @opentrain 									| 							| |
+| ``DEC`` 			| @kiwitreekor, @kimgas 									| 							| #15 |
+| ``ECOBEE`` 			| @SerpensNebula 										| 							| #38 |
+| ``EEC`` 			| @kiwitreekor, @kimgas 									| 							| #15 |
+| ``K2x00`` 			| @opentrain 											| 							| #90 |
+| ``K4x00`` 			| Original: unknown<br />Las 									| 							| <https://cafe.naver.com/ottd/10534> |
+| V-train and its wagons 	| Las<br />Modified by @EightonEight 								| 							| <https://cafe.naver.com/ottd/10466><br />modified: #390 |
+| ``K5000`` 			| @kiwitreekor<br />Modified by @SerpensNebula 							| 							| #176<br />modified: #352 |
+| ``K6x00`` 			| @kiwitreekor, @SerpensNebula 									| 							| #176, #250<br />modified: #352 |
+| Kwankwang-ho livery	 	| @SerpensNebula 										| 							| #241 |
+| ``K7000`` 			| Modified by Las, @SerpensNebula 								| 							| <https://cafe.naver.com/ottd/10534>, #353 |
+| ``K7x00`` 			| @kiwitreekor<br />Modified by @SerpensNebula, @JukjeonWani 					| 							| modified: #351, #360 |
+| G-train and its wagons 	| @opentrain<br />Modified by @telk5093, @JukjeonWani 						| 							| <https://cafe.naver.com/ottd/10464><br />modified: #127, #223, #361, #387 |
+| Haerang and its wagons 	| Las?<br />Modified by @JukjeonWani 								| 							| modified: #361 |
+| S-train and its wagons 	| Las<br />Modified by @JukjeonWani 								| 							| <https://cafe.naver.com/ottd/10466><br />modified: #361 |
+| ``K7600`` 			| skyu 												| 							| |
+| A-train and its wagons 	| @kiwitreekor, @kimgas<br />Modified by @JukjeonWani 						| 							| #15<br />modified: #361 |
+| ``K8000`` 			| skyu 												| 							| |
+| ``K8x00`` 			| skyu<br />Modified by @SerpensNebula 								| 							| modified: #359 |
+| ``K8500`` 			| skyu<br />Modified by @SerpensNebula 								| 							| modified: #359 |
+| ``EUM`` 			| skyu<br />Modified by @EightonEight 								| 							| modified: #370, #376 |
+| ``EUM_32bpp`` 		| @kiwitreekor<br />Modified by @EightonEight 							| 							| #319, #320<br />modified: #370, #376 |
+| KTX-EUM 320 wagon 		| @EightonEight 										| 							| #368 |
+| ``KTX1N`` 			| skyu 												| @SerpensNebula<br />Modified by @EightonEight 	| template changed: #427<br />modified: #437, #442 |
+| ``KTX2N`` 			| Las<br />Modified by @EightonEight 								| 							| modified: #376, #377 |
+| ``KTX2N_PYEONGCHANG`` 	| RIPper<br />Modified by @EightonEight 							| 							| #89<br />modified: #376, #377 |
+| ``SRT`` 			| Las<br />Modified by @EightonEight 								| 							| modified: #377 |
+| ``SRT_32bpp`` 		| @EightonEight 										| 							| #377 |
+| ``MAUM`` 			| 												| @SerpensNebula 					| #307<br />modified: #428, #444 |
+| ``MAUM_32bpp`` 		| 												| @SerpensNebula 					| #307<br />modified: #428, #444 |
+| ``NDC`` 			| Original: unknown<br />Modified by @telk5093, @kiwitreekor 					| 							| modified: #15 |
+| ``NURIRO`` 			| @telk5093<br />(original: ``ITX_CHEONGCHUN``)<br />Modified by @kimgas, @EightonEight 	| 							| modified: #140, #362 |
+| ``NURIRO_SANTA`` 		| @kiwitreekor<br />Modified by @kimgas 							| 							| #106<br />modified: #140 |
+| ``DHC`` 			| skyu<br />modified by @telk5093 								| 							| modified: #34 |
+| ``ITX-saemaeul`` 		| Las<br />Modified by @EightonEight 								| 							| <https://cafe.naver.com/ottd/7468><br />modified: #376 |
+| ``MIKA3`` 			| @SerpensNebula 										| @SerpensNebula 					| #37<br />modified: #276<br />template changed: #445 |
+| ``PASHI5`` 			| @SerpensNebula 										| @SerpensNebula 					| #37<br />modified: #276<br />template changed: #445 |
+| ``MATE2`` 			| @SerpensNebula 										| @SerpensNebula 					| #37<br />modified: #276<br />template changed: #445 |
 
-## LRT
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``BUSAN_4K`` | 초저항 | |
-| ``BUSANGIMHAE`` | Las? | |
-| ``DAEGU_3K_1`` | Jakga? | |
-| ``DAEGU_3K_2`` | Jakga? | |
-| ``GIMPO_1K`` | skyu?<br />Middle wagon: [@telk5093](https://github.com/telk5093) | |
-| ``INCHEON_METRO_2K`` | Las | <https://cafe.naver.com/ottd/10435> |
-| ``SILLIM`` | [@SerpensNebula](https://github.com/SerpensNebula)<br />Modified by [@Coconut](https://github.com/CoconutKR) | [#16](https://github.com/KoreanGRF/KoreanTrainSet/issues/16)<br />modified: [#343](https://github.com/KoreanGRF/KoreanTrainSet/issues/343) |
-| ``U100`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#33](https://github.com/KoreanGRF/KoreanTrainSet/issues/33) |
-| ``UL000`` | Las | <https://cafe.naver.com/ottd/10435> |
-| ``Y100`` | [@telk5093](https://github.com/telk5093) | |
+### LRT
+| Code 			| Author (legacy) 				| Author (standard) 	| Reference |
+|-----------------------|-----------------------------------------------|-----------------------|-----------|
+| ``BUSAN_4K`` 		| 초저항 					| 			| |
+| ``BUSANGIMHAE`` 	| Las? 						| 			| |
+| ``DAEGU_3K_1`` 	| Jakga? 					| 			| |
+| ``DAEGU_3K_2`` 	| Jakga? 					| 			| |
+| ``GIMPO_1K`` 		| skyu?<br />Middle wagon: @telk5093 		| 			| |
+| ``INCHEON_METRO_2K`` 	| Las 						| 			| <https://cafe.naver.com/ottd/10435> |
+| ``SILLIM`` 		| @SerpensNebula<br />Modified by @Coconut 	| 			| #16<br />modified: #343 |
+| ``U100`` 		| @SerpensNebula 				| 			| #33 |
+| ``UL000`` 		| Las 						| 			| <https://cafe.naver.com/ottd/10435> |
+| ``Y100`` 		| @telk5093 					| 			| |
 
-## metro
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``AREX_1K_NONSTOP`` | skyu | |
-| ``AREX_1K_NONSTOP_ORANGE`` | [@kiwitreekor](https://github.com/kiwitreekor) | [#6](https://github.com/KoreanGRF/KoreanTrainSet/issues/6) |
-| ``AREX_2K`` | skyu | |
-| ``BUSAN_METRO_1K_1ST`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#270](https://github.com/KoreanGRF/KoreanTrainSet/issues/270) |
-| ``BUSAN_METRO_1K_2ND`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#303](https://github.com/KoreanGRF/KoreanTrainSet/issues/303), [#364](https://github.com/KoreanGRF/KoreanTrainSet/pull/364) |
-| ``BUSAN_METRO_1K_3RD`` | [@EightonEight](https://github.com/EightonEight) | [#363](https://github.com/KoreanGRF/KoreanTrainSet/issues/363) |
-| ``BUSAN_METRO_2K`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#270](https://github.com/KoreanGRF/KoreanTrainSet/issues/270), [#364](https://github.com/KoreanGRF/KoreanTrainSet/pull/364) |
-| ``BUSAN_METRO_3K`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#303](https://github.com/KoreanGRF/KoreanTrainSet/issues/303) |
-| ``DAEGU_METRO_1K`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#364](https://github.com/KoreanGRF/KoreanTrainSet/pull/364) |
-| ``DAEGU_METRO_2K`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#303](https://github.com/KoreanGRF/KoreanTrainSet/issues/303) |
-| ``DAEJEON_METRO_1K`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#303](https://github.com/KoreanGRF/KoreanTrainSet/issues/303) |
-| ``GWANGJU_METRO_1K`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#303](https://github.com/KoreanGRF/KoreanTrainSet/issues/303) |
-| ``361K_VVVF`` | skyu | |
-| ``368K_ITX_CHEONGCHUN`` | skyu | |
-| ``INCHEON_METRO_1K_VVVF_1ST`` | skyu<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#303](https://github.com/KoreanGRF/KoreanTrainSet/issues/303) |
-| ``INCHEON_METRO_1K_VVVF_1ST_2022`` | [@EightonEight](https://github.com/EightonEight) | [#373](https://github.com/KoreanGRF/KoreanTrainSet/issues/373) |
-| ``INCHEON_METRO_1K_VVVF_2ND`` | Las | <https://cafe.naver.com/ottd/10466> |
-| ``391K_1ST`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight) | <https://cafe.naver.com/ottd/13880><br />modified: [#311](https://github.com/KoreanGRF/KoreanTrainSet/pull/311) |
-| ``391K_2ND`` | [@EightonEight](https://github.com/EightonEight) | [#260](https://github.com/KoreanGRF/KoreanTrainSet/issues/260) |
-| ``1K_RHEO_FIRST_1`` | skyu<br />Modified by [@ChuoSpecialRapid201](https://github.com/ChuoSpecialRapid201) | modified: [#240](https://github.com/KoreanGRF/KoreanTrainSet/issues/240) |
-| ``1K_RHEO_FIRST_2`` | 〃 | 〃 |
-| ``1K_RHEO_SECOND_1`` | 〃 | 〃 |
-| ``1K_RHEO_SECOND_2`` | 〃 | 〃 |
-| ``1K_RHEO_SECOND_3`` | 〃 | 〃 |
-| ``1K_RHEO_LAST_1`` | 〃 | 〃 |
-| ``1K_RHEO_LAST_2`` | 〃 | 〃 |
-| ``3XXK_AL`` | skyu | |
-| ``3XXK_ST`` | skyu<br />Modified by [@EightonEight](https://github.com/EightonEight) (Single arm pantograph) | modified: [#271](https://github.com/KoreanGRF/KoreanTrainSet/issues/271) |
-| ``311K_1_1`` | skyu | |
-| ``311K_1_2`` | skyu | |
-| ``311K_2_1`` | skyu | |
-| ``311K_2_2`` | skyu | |
-| ``321K_BIKE`` | [@opentrain](https://github.com/opentrain) | |
-| ``371K_381K_1ST`` | skyu<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#311](https://github.com/KoreanGRF/KoreanTrainSet/pull/311) |
-| ``371K_BLANK`` | skyu<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#271](https://github.com/KoreanGRF/KoreanTrainSet/issues/271) |
-| ``371K_CC`` | [@EightonEight](https://github.com/EightonEight) | [#271](https://github.com/KoreanGRF/KoreanTrainSet/issues/271) |
-| ``381K_2ND`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@telk5093](https://github.com/telk5093), [@EightonEight](https://github.com/EightonEight) | <https://cafe.naver.com/ottd/13880><br />modified: [#271](https://github.com/KoreanGRF/KoreanTrainSet/issues/271), [#295](https://github.com/KoreanGRF/KoreanTrainSet/issues/295), [#311](https://github.com/KoreanGRF/KoreanTrainSet/pull/311) |
-| ``LINE_1_2019`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#271](https://github.com/KoreanGRF/KoreanTrainSet/issues/271), [#295](https://github.com/KoreanGRF/KoreanTrainSet/issues/295), [#311](https://github.com/KoreanGRF/KoreanTrainSet/pull/311) |
-| ``LINE_1_2021`` | [@EightonEight](https://github.com/EightonEight) | [#295](https://github.com/KoreanGRF/KoreanTrainSet/issues/295)<br />modified: [#311](https://github.com/KoreanGRF/KoreanTrainSet/pull/311) |
-| ``LINE_1_2022_W`` | [@EightonEight](https://github.com/EightonEight) | [#345](https://github.com/KoreanGRF/KoreanTrainSet/issues/345) |
-| ``SMETRO_1K_RHEO_FIRST`` | skyu | |
-| ``SMETRO_1K_RHEO_MODIFIED`` | skyu<br />Modified by [@ChuoSpecialRapid201](https://github.com/ChuoSpecialRapid201) | modified: [#240](https://github.com/KoreanGRF/KoreanTrainSet/issues/240) |
-| ``SMETRO_1K_VVVF`` | skyu | |
-| ``2K_CHOPPER`` | skyu | |
-| ``2K_MELCO`` | skyu | |
-| ``2K_RHEO_MODIFIED`` | [@opentrain](https://github.com/opentrain) | |
-| ``2K_VVVF_1ST`` | skyu | |
-| ``2K_VVVF_2ND`` | skyu | |
-| ``2K_VVVF_2ND`` | skyu | |
-| ``2K_VVVF_3RD`` | skyu<br />Modified by [@kiwitreekor](https://github.com/kiwitreekor), [@EightonEight](https://github.com/EightonEight) | [#47](https://github.com/KoreanGRF/KoreanTrainSet/issues/47), [#303](https://github.com/KoreanGRF/KoreanTrainSet/issues/303) |
-| ``2K_VVVF_4TH`` | [@kiwitreekor](https://github.com/kiwitreekor) | [#9](https://github.com/KoreanGRF/KoreanTrainSet/issues/9) |
-| ``3K_SMETRO_CHOPPER`` | skyu | |
-| ``3K_SMETRO_MODIFIED_CHOPPER`` | skyu | |
-| ``3K_SMETRO_VVVF_1ST`` | skyu | |
-| ``3K_SMETRO_VVVF_2ND`` | [@kimgas](https://github.com/kimgas) | [#51](https://github.com/KoreanGRF/KoreanTrainSet/issues/51) |
-| ``3K_VVVF_1ST_1`` | skyu | |
-| ``3K_VVVF_1ST_2`` | skyu<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#308](https://github.com/KoreanGRF/KoreanTrainSet/pull/308) |
-| ``LINE_3_2022`` | [@EightonEight](https://github.com/EightonEight) | [#331](https://github.com/KoreanGRF/KoreanTrainSet/issues/331) |
-| ``LINE_3_2022_W`` | [@EightonEight](https://github.com/EightonEight) | [#375](https://github.com/KoreanGRF/KoreanTrainSet/issues/375) |
-| ``341K_VVVF_1ST_1`` | skyu | |
-| ``341K_VVVF_1ST_2`` | skyu | |
-| ``341K_VVVF_2ND_1`` | skyu | |
-| ``341K_VVVF_2ND_2`` | skyu | |
-| ``LINE_4_2019`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight) | modified: [#271](https://github.com/KoreanGRF/KoreanTrainSet/issues/271), [#295](https://github.com/KoreanGRF/KoreanTrainSet/issues/295), [#311](https://github.com/KoreanGRF/KoreanTrainSet/pull/311), [#380](https://github.com/KoreanGRF/KoreanTrainSet/pull/380) |
-| ``LINE_4_2021`` | [@EightonEight](https://github.com/EightonEight) | [#295](https://github.com/KoreanGRF/KoreanTrainSet/issues/295)<br />modified: [#311](https://github.com/KoreanGRF/KoreanTrainSet/pull/311), [#380](https://github.com/KoreanGRF/KoreanTrainSet/pull/380) |
-| ``SMETRO_4K_VVVF_1ST_2ND`` | [@EightonEight](https://github.com/EightonEight) | [#83](https://github.com/KoreanGRF/KoreanTrainSet/issues/83) |
-| ``SMETRO_4K_VVVF_3RD`` | [@kiwitreekor](https://github.com/kiwitreekor) | [#12](https://github.com/KoreanGRF/KoreanTrainSet/issues/12) |
-| ``SMETRO_4K_VVVF_4TH`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | [#304](https://github.com/KoreanGRF/KoreanTrainSet/issues/304) |
-| ``SMETRO_5K_1ST_2ND`` | skyu | |
-| ``SMETRO_5K_3RD`` | Maybe [@telk5093](https://github.com/telk5093)<br>(original: skyu, modified by from Line 5) |  |
-| ``SMETRO_5K_4TH`` | [@kimgas](https://github.com/kimgas) | [#41](https://github.com/KoreanGRF/KoreanTrainSet/issues/41) |
-| ``SMETRO_6K_1ST`` | skyu | |
-| ``SMETRO_7K_1ST_2ND`` | skyu  | |
-| ``SMETRO_7K_4TH`` | [@kiwitreekor](https://github.com/kiwitreekor) | [#13](https://github.com/KoreanGRF/KoreanTrainSet/issues/13) |
-| ``SMETRO_7K_5TH`` | [@opentrain](https://github.com/opentrain) | [#216](https://github.com/KoreanGRF/KoreanTrainSet/issues/216) |
-| ``SMETRO_8K_1ST_2ND`` | skyu | |
-| ``SMETRO_8K_3RD`` | [@opentrain](https://github.com/opentrain)<br />Modified by [@EightonEight](https://github.com/EightonEight) | [#256](https://github.com/KoreanGRF/KoreanTrainSet/issues/256) |
-| ``SMETRO_9K_1ST`` | skyu | |
-| ``SMETRO_SR0X`` | skyu | |
-| ``D00`` | skyu | |
-| ``351K_2021`` | [@EightonEight](https://github.com/EightonEight) | [#295](https://github.com/KoreanGRF/KoreanTrainSet/issues/295)<br />modified: [#311](https://github.com/KoreanGRF/KoreanTrainSet/pull/311) |
-| ``351K_VVVF_1ST`` | skyu | |
-| ``351K_VVVF_2ND`` | skyu | |
-| ``351K_VVVF_3RD`` | skyu | |
-| ``351K_VVVF_3RD_SINGLE_ARM`` | [@telk5093](https://github.com/telk5093)<br>(original: skyu) | |
+### metro
+| Code 					| Author (legacy) 						| Author (standard) 	| Reference |
+|---------------------------------------|---------------------------------------------------------------|-----------------------|-----------|
+| ``AREX_1K_NONSTOP`` 			| skyu 								| @EightonEight 	| template changed: #441, hereinafter the same |
+| ``AREX_1K_NONSTOP_ORANGE`` 		| @kiwitreekor 							| 〃 			| #6 |
+| ``AREX_2K`` 				| skyu 								| 〃 			| |
+| ``BUSAN_METRO_1K_1ST`` 		| @opentrain<br />Modified by @EightonEight 			| 〃 			| modified: #270 |
+| ``BUSAN_METRO_1K_2ND`` 		| @opentrain<br />Modified by @EightonEight 			| 〃 			| modified: #303, #364 |
+| ``BUSAN_METRO_1K_3RD`` 		| 								| 〃 			| #363 |
+| ``BUSAN_METRO_2K`` 			| @opentrain<br />Modified by @EightonEight 			| 〃 			| modified: #270, #364 |
+| ``BUSAN_METRO_3K`` 			| @opentrain<br />Modified by @EightonEight 			| 〃 			| modified: #303 |
+| ``DAEGU_METRO_1K`` 			| @opentrain<br />Modified by @EightonEight 			| 〃 			| modified: #364 |
+| ``DAEGU_METRO_2K`` 			| @opentrain<br />Modified by @EightonEight 			| 〃 			| modified: #303 |
+| ``DAEJEON_METRO_1K`` 			| @opentrain<br />Modified by @EightonEight 			| 〃 			| modified: #303 |
+| ``GWANGJU_METRO_1K`` 			| @opentrain<br />Modified by @EightonEight 			| 〃 			| modified: #303 |
+| ``361K_VVVF`` 			| skyu 								| 〃 			| |
+| ``368K_ITX_CHEONGCHUN`` 		| skyu 								| 〃 			| |
+| ``INCHEON_METRO_1K_VVVF_1ST`` 	| skyu<br />Modified by @EightonEight 				| 〃 			| modified: #303 |
+| ``INCHEON_METRO_1K_VVVF_1ST_2022`` 	| @EightonEight 						| 〃 			| #373 |
+| ``INCHEON_METRO_1K_VVVF_2ND`` 	| Las 								| 〃 			| <https://cafe.naver.com/ottd/10466> |
+| ``391K_1ST`` 				| @kiwitreekor<br />Modified by @EightonEight 			| 〃 			| <https://cafe.naver.com/ottd/13880><br />modified: #311 |
+| ``391K_2ND`` 				| @EightonEight 						| 〃 			| #260 |
+| ``1K_RHEO_FIRST_1`` 			| skyu<br />Modified by @ChuoSpecialRapid201 			| 〃 			| modified: #240 |
+| ``1K_RHEO_FIRST_2`` 			| 〃 								| 〃 			| 〃 |
+| ``1K_RHEO_SECOND_1`` 			| 〃 								| 〃 			| 〃 |
+| ``1K_RHEO_SECOND_2`` 			| 〃 								| 〃 			| 〃 |
+| ``1K_RHEO_SECOND_3`` 			| 〃 								| 〃 			| 〃 |
+| ``1K_RHEO_LAST_1`` 			| 〃 								| 〃 			| 〃 |
+| ``1K_RHEO_LAST_2`` 			| 〃 								| 〃 			| 〃 |
+| ``3XXK_AL`` 				| skyu 								| 〃 			| |
+| ``3XXK_ST`` 				| skyu<br />Modified by @EightonEight 				| 〃 			| modified: #271 |
+| ``311K_1_1`` 				| skyu 								| 〃 			| |
+| ``311K_1_2`` 				| skyu 								| 〃 			| |
+| ``311K_2_1`` 				| skyu 								| 〃 			| |
+| ``311K_2_2`` 				| skyu 								| 〃 			| |
+| ``321K_BIKE`` 			| @opentrain 							| 〃 			| |
+| ``371K_381K_1ST`` 			| skyu<br />Modified by @EightonEight 				| 〃 			| modified: #311 |
+| ``371K_BLANK`` 			| skyu<br />Modified by @EightonEight 				| 〃 			| modified: #271 |
+| ``371K_CC`` 				| @EightonEight 						| 〃 			| #271 |
+| ``381K_2ND`` 				| @kiwitreekor<br />Modified by @telk5093, @EightonEight 	| 〃 			| <https://cafe.naver.com/ottd/13880><br />modified: #271, #295, #311 |
+| ``LINE_1_2019`` 			| @kiwitreekor<br />Modified by @EightonEight 			| 〃 			| modified: #271, #295, #311 |
+| ``LINE_1_2021`` 			| @EightonEight 						| 〃 			| #295<br />modified: #311 |
+| ``LINE_1_2022_W`` 			| @EightonEight 						| 〃 			| #345 |
+| ``SMETRO_1K_RHEO_FIRST`` 		| skyu 								| 〃 			| |
+| ``SMETRO_1K_RHEO_MODIFIED`` 		| skyu<br />Modified by @ChuoSpecialRapid201 			| 〃 			| modified: #240 |
+| ``SMETRO_1K_VVVF`` 			| skyu 								| 〃 			| |
+| ``2K_CHOPPER`` 			| skyu 								| 〃 			| |
+| ``2K_MELCO`` 				| skyu 								| 〃 			| |
+| ``2K_RHEO_MODIFIED`` 			| @opentrain 							| 〃 			| |
+| ``2K_VVVF_1ST`` 			| skyu 								| 〃 			| |
+| ``2K_VVVF_2ND`` 			| skyu 								| 〃 			| |
+| ``2K_VVVF_2ND`` 			| skyu 								| 〃 			| |
+| ``2K_VVVF_3RD`` 			| skyu<br />Modified by @kiwitreekor, @EightonEight 		| 〃 			| #47, #303 |
+| ``2K_VVVF_4TH`` 			| @kiwitreekor 							| 〃 			| #9 |
+| ``3K_SMETRO_CHOPPER`` 		| skyu 								| 〃 			| |
+| ``3K_SMETRO_MODIFIED_CHOPPER`` 	| skyu 								| 〃 			| |
+| ``3K_SMETRO_VVVF_1ST`` 		| skyu 								| 〃 			| |
+| ``3K_SMETRO_VVVF_2ND`` 		| @kimgas 							| 〃 			| #51 |
+| ``3K_VVVF_1ST_1`` 			| skyu 								| 〃 			| |
+| ``3K_VVVF_1ST_2`` 			| skyu<br />Modified by @EightonEight 				| 〃 			| modified: #308 |
+| ``LINE_3_2022`` 			| @EightonEight 						| 〃 			| #331 |
+| ``LINE_3_2022_W`` 			| @EightonEight 						| 〃 			| #375 |
+| ``341K_VVVF_1ST_1`` 			| skyu 								| 〃 			| |
+| ``341K_VVVF_1ST_2`` 			| skyu 								| 〃 			| |
+| ``341K_VVVF_2ND_1`` 			| skyu 								| 〃 			| |
+| ``341K_VVVF_2ND_2`` 			| skyu 								| 〃 			| |
+| ``LINE_4_2019`` 			| @kiwitreekor<br />Modified by @EightonEight 			| 〃 			| modified: #271, #295, #311, #380 |
+| ``LINE_4_2021`` 			| @EightonEight 						| 〃 			| #295<br />modified: #311, #380 |
+| ``SMETRO_4K_VVVF_1ST_2ND`` 		| @EightonEight 						| 〃 			| #83 |
+| ``SMETRO_4K_VVVF_3RD`` 		| @kiwitreekor 							| 〃 			| #12 |
+| ``SMETRO_4K_VVVF_4TH`` 		| @opentrain				 			| 〃 			| #304 |
+| ``SMETRO_5K_1ST_2ND`` 		| skyu 								| 〃 			| |
+| ``SMETRO_5K_3RD`` 			| Maybe @telk5093<br>(original: ``SMETRO_9K_1ST``) 		| 〃 			| |
+| ``SMETRO_5K_4TH`` 			| @kimgas 							| 〃 			| #41 |
+| ``SMETRO_6K_1ST`` 			| skyu 								| 〃 			| |
+| ``SMETRO_7K_1ST_2ND`` 		| skyu  							| 〃 			| |
+| ``SMETRO_7K_4TH`` 			| @kiwitreekor 							| 〃 			| #13 |
+| ``SMETRO_7K_5TH`` 			| @opentrain 							| 〃 			| #216 |
+| ``SMETRO_8K_1ST_2ND`` 		| skyu 								| 〃 			| |
+| ``SMETRO_8K_3RD`` 			| @opentrain<br />Modified by @EightonEight 			| 〃 			| #256 |
+| ``SMETRO_9K_1ST`` 			| skyu 								| 〃 			| |
+| ``SMETRO_SR0X`` 			| skyu 								| 〃 			| |
+| ``D00`` 				| skyu 								| 〃 			| |
+| ``351K_2021`` 			| @EightonEight 						| 〃 			| #295<br />modified: #311 |
+| ``351K_VVVF_1ST`` 			| skyu 								| 〃 			| |
+| ``351K_VVVF_2ND`` 			| skyu 								| 〃 			| |
+| ``351K_VVVF_3RD`` 			| skyu<br />Modified by @telk5093 				| 〃 			| |
 
-## misc
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``simple_waypoint`` | Modified by [@telk5093](https://github.com/telk5093) | modified from OpenGFX |
+### narrow
+| Code 				| Author (legacy) 	| Author (standard) 	| Reference |
+|-------------------------------|-----------------------|-----------------------|-----------|
+| ``NARROW_BOXCAR`` 		| @SerpensNebula 	| 			| #215 |
+| ``HOKEY7`` 			| 〃 			| 			| #205<br />modified: #276 |
+| ``NARROW_HOPPERCAR`` 		| 〃 			| 			| #217 |
+| ``NARROW_DIESEL_CAR`` 	| 〃 			| 			| #205 |
+| ``NARROW_GAUGE_WAGON`` 	| 〃 			| 			| #205 |
 
-## narrow
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``NARROW_BOXCAR`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#215](https://github.com/KoreanGRF/KoreanTrainSet/issues/215) |
-| ``HOKEY7`` | 〃 | [#205](https://github.com/KoreanGRF/KoreanTrainSet/issues/205)<br />modified: [#276](https://github.com/KoreanGRF/KoreanTrainSet/issues/276) |
-| ``NARROW_HOPPERCAR`` | 〃 | [#217](https://github.com/KoreanGRF/KoreanTrainSet/issues/217) |
-| ``NARROW_DIESEL_CAR`` | 〃 | [#205](https://github.com/KoreanGRF/KoreanTrainSet/issues/205) |
-| ``NARROW_GAUGE_WAGON`` | 〃 | [#205](https://github.com/KoreanGRF/KoreanTrainSet/issues/205) |
+### wagon
+| Code 				| Author (legacy) 								| Author (standard) 	| Reference |
+|-------------------------------|-------------------------------------------------------------------------------|-----------------------|-----------|
+| ``BAGGAGE_CAR`` 		| @opentrain 									| @EightonEight 	| modified: #389 |
+| ``BIDULGI`` (Baggage_car) 	| @SerpensNebula 								| 			| #40 |
+| ``BIDULGI_CAR`` 		| @SerpensNebula 								| @SerpensNebula 	| #40<br />template changed: #432 |
+| ``BOX_CAR`` 			| @opentrain, @EightonEight 							| 			| #138 |
+| ``BULK_CEMENT_CAR`` 		| 		 								| @EightonEight 	| #372 |
+| ``CAFE_CAR`` 			| Modified by @ChuoSpecialRapid201, @JukjeonWani 				| @SerpensNebula 	| #86, #87, #118, #136, #139, #141, #145, #184, #185, #358, #367 |
+| ``FLAT_CAR`` 			| skyu<br />Modified by @kiwitreekor, @kimgas, @EightonEight 			| @SerpensNebula 	| modified: #157, #403 |
+| ``generator_car`` 		| Original: unknown<br />@kimgas, @ChuoSpecialRapid201, @opentrain 		| 			| #117, #232, #233 |
+| ``HOPPER_CAR`` 		| @kiwitreekor 									| 			| <https://cafe.naver.com/ottd/15106> |
+| ``cargo_AORE`` 		| 〃 										| 			| |
+| ``cargo_BEAN`` 		| 〃 										| 			| |
+| ``cargo_CLAY`` 		| 〃 										| 			| |
+| ``cargo_COAL`` 		| 〃 										| 			| |
+| ``cargo_CORE`` 		| 〃 										| 			| |
+| ``cargo_FRUT`` 		| 〃 										| 			| |
+| ``cargo_GOLD`` 		| 〃 										| 			| |
+| ``cargo_GRAI`` 		| 〃 										| 			| |
+| ``cargo_GRVL`` 		| 〃 										| 			| |
+| ``cargo_IORE`` 		| 〃 										| 			| |
+| ``cargo_LIME`` 		| 〃 										| 			| |
+| ``cargo_MNO2`` 		| 〃 										| 			| |
+| ``cargo_PHOS`` 		| 〃 										| 			| |
+| ``cargo_PORE`` 		| 〃 										| 			| |
+| ``cargo_RCYC`` 		| 〃 										| 			| |
+| ``cargo_SALT`` 		| 〃 										| 			| |
+| ``cargo_SAND`` 		| 〃 										| 			| |
+| ``cargo_SCMT`` 		| 〃 										| 			| |
+| ``cargo_SLAG`` 		| 〃 										| 			| |
+| ``MAIL_CAR`` 			| @kimgas<br />Modified by @EightonEight 					| 			| #126<br />modified: #390 |
+| ``MUGUNGHWA_CAR`` 		| skyu?<br />@ChuoSpecialRapid201, @opentrain<br />Modified by @JukjeonWani 	| @SerpensNebula 	| #113, #124, #131, #174<br />modified: #180, #341, #357<br />template changed: #430 |
+| ``passenger_wagon`` 		| @telk5093 									| 			| |
+| ``KWANKWANG_CAR`` 		| @SerpensNebula 							 	| @SerpensNebula 	| #241<br />template changed: #433 |
+| ``SAEMAEUL_CAR`` 		| skyu?<br />@ChuoSpecialRapid201, @EightonEight<br />Modified by @JukjeonWani 	| @SerpensNebula 	| #118, #184, #227<br />modified: #378, #450<br />template changed: #429 |
+| ``SLEEPING_CAR`` 		| @ChuoSpecialRapid201, @opentrain		 				| @EightonEight 	| #123, #220<br />template changed: #421 |
+| ``STAKE_CAR`` 		| @kiwitreekor<br />Modified by @kimgas, @EightonEight		 		| @SerpensNebula 	| <https://cafe.naver.com/ottd/15106><br />modified: #157, #403 |
+| ``STAKE_CAR_without_stake`` 	| @EightonEight 				 				| 〃 			| #257<br />modified: #157, #403 |
+| ``cargo_BUBL`` 		| @SerpensNebula<br />Modified by @kiwitreekor, @EightonEight 			| 〃 			| #55<br />modified: #157, #403 |
+| ``cargo_COPR`` 		| @kiwitreekor<br />Modified by @EightonEight		 			| 〃 			| <https://cafe.naver.com/ottd/15106><br />modified: #157, #403 |
+| ``cargo_ENSP`` 		| @EightonEight		 							| 〃 			| #257<br />modified: #157, #403 |
+| ``cargo_FMSP`` 		| @EightonEight		 							| 〃 			| #257<br />modified: #157, #403 |
+| ``cargo_PAPR`` 		| @kiwitreekor<br />Modified by @EightonEight		 			| 〃 			| <https://cafe.naver.com/ottd/15106><br />modified: #157, #403 |
+| ``cargo_PIPE`` 		| @kiwitreekor<br />Modified by @EightonEight		 			| 〃 			| <https://cafe.naver.com/ottd/15106><br />modified: #157, #403 |
+| ``cargo_STEL`` 		| @kiwitreekor<br />Modified by @kimgas, @EightonEight		 		| 〃 			| <https://cafe.naver.com/ottd/15106><br />modified: #157, #403 |
+| ``cargo_TYRE`` 		| @kiwitreekor<br />Modified by @telk5093, @EightonEight		 	| 〃 			| modified: #157, #403 |
+| ``cargo_VBOD`` 		| @kiwitreekor<br />Modified by @EightonEight		 			| 〃 			| <https://cafe.naver.com/ottd/15106><br />modified: #157, #403 |
+| ``cargo_VEHI`` 		| 〃 										| 〃 			| modified: #157, #403 |
+| ``cargo_WDPR`` 		| 〃 										| 〃 			| modified: #157, #403 |
+| ``cargo_WOOD`` 		| 〃 										| 〃 			| modified: #157, #403 |
+| ``cargo_WOOL`` 		| 〃 										| 〃 			| modified: #157, #403 |
+| ``TANK_CAR`` 			| @kiwitreekor				 					| @EightonEight 	| <https://cafe.naver.com/ottd/15106><br />modified: #372 |
+| ``TONGIL_CAR`` 		| @SerpensNebula 								| @SerpensNebula 	| #134<br />template changed: #431 |
 
-## object
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``KR_BUFFER`` | [@telk5093](https://github.com/telk5093) | |
+## etc.
+### misc
+| Code 			| Author 			| Reference |
+|-----------------------|-------------------------------|-----------|
+| ``simple_waypoint`` 	| Modified by @telk5093 	| modified from OpenGFX |
 
-## railtype
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``KR_LIGHTRAIL`` | 초저항 | |
-| ``NARROW_GAUGE`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#204](https://github.com/KoreanGRF/KoreanTrainSet/issues/204) |
+### object
+| Code 			| Author 	| Reference |
+|-----------------------|---------------|-----------|
+| ``KR_BUFFER`` 	| @telk5093 	| |
 
-## wagon
-| Code | Author | Reference |
-|------|--------|-----------|
-| ``BAGGAGE_CAR`` | [@opentrain](https://github.com/opentrain) | |
-| ``BIDULGI`` (Baggage_car) |[@SerpensNebula](https://github.com/SerpensNebula) | [#40](https://github.com/KoreanGRF/KoreanTrainSet/issues/40) |
-| ``BIDULGI_CAR`` |[@SerpensNebula](https://github.com/SerpensNebula) | [#40](https://github.com/KoreanGRF/KoreanTrainSet/issues/40) |
-| ``BOX_CAR`` | [@opentrain](https://github.com/opentrain), [@EightonEight](https://github.com/EightonEight) | [#138](https://github.com/KoreanGRF/KoreanTrainSet/issues/138) |
-| ``BULK_CEMENT_CAR`` | [@EightonEight](https://github.com/EightonEight) | [#372](https://github.com/KoreanGRF/KoreanTrainSet/issues/372) |
-| ``CAFE_CAR`` | Modified by [@ChuoSpecialRapid201](https://github.com/ChuoSpecialRapid201), [@JukjeonWani](https://github.com/JukjeonWani) | [#86](https://github.com/KoreanGRF/KoreanTrainSet/issues/86), [#87](https://github.com/KoreanGRF/KoreanTrainSet/issues/87), [#118](https://github.com/KoreanGRF/KoreanTrainSet/issues/118), [#136](https://github.com/KoreanGRF/KoreanTrainSet/issues/136), [#139](https://github.com/KoreanGRF/KoreanTrainSet/issues/139), [#141](https://github.com/KoreanGRF/KoreanTrainSet/issues/141), [#145](https://github.com/KoreanGRF/KoreanTrainSet/issues/145), [#184](https://github.com/KoreanGRF/KoreanTrainSet/issues/184), [#185](https://github.com/KoreanGRF/KoreanTrainSet/issues/185), [#358](https://github.com/KoreanGRF/KoreanTrainSet/issues/358) |
-| ``FLAT_CAR`` | skyu<br />Modified by [@kiwitreekor](https://github.com/kiwitreekor), [@kimgas](https://github.com/kimgas), [@EightonEight](https://github.com/EightonEight), [@SerpensNebula](https://github.com/SerpensNebula) | modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``generator_car`` | Original: unknown<br />[@kimgas](https://github.com/kimgas), [@ChuoSpecialRapid201](https://github.com/ChuoSpecialRapid201), [@opentrain](https://github.com/opentrain) | [#117](https://github.com/KoreanGRF/KoreanTrainSet/issues/117), [#232](https://github.com/KoreanGRF/KoreanTrainSet/issues/232), [#233](https://github.com/KoreanGRF/KoreanTrainSet/issues/233) |
-| ``HOPPER_CAR`` | [@kiwitreekor](https://github.com/kiwitreekor) | <https://cafe.naver.com/ottd/15106> |
-| ``cargo_AORE`` | 〃 | |
-| ``cargo_BEAN`` | 〃 | |
-| ``cargo_CLAY`` | 〃 | |
-| ``cargo_COAL`` | 〃 | |
-| ``cargo_CORE`` | 〃 | |
-| ``cargo_FRUT`` | 〃 | |
-| ``cargo_GOLD`` | 〃 | |
-| ``cargo_GRAI`` | 〃 | |
-| ``cargo_GRVL`` | 〃 | |
-| ``cargo_IORE`` | 〃 | |
-| ``cargo_LIME`` | 〃 | |
-| ``cargo_MNO2`` | 〃 | |
-| ``cargo_PHOS`` | 〃 | |
-| ``cargo_PORE`` | 〃 | |
-| ``cargo_RCYC`` | 〃 | |
-| ``cargo_SALT`` | 〃 | |
-| ``cargo_SAND`` | 〃 | |
-| ``cargo_SCMT`` | 〃 | |
-| ``cargo_SLAG`` | 〃 | |
-| ``MAIL_CAR`` | [@kimgas](https://github.com/kimgas)<br />Modified by [@EightonEight](https://github.com/EightonEight) | [#126](https://github.com/KoreanGRF/KoreanTrainSet/issues/126)<br />modified: [#390](https://github.com/KoreanGRF/KoreanTrainSet/pull/390) |
-| ``MUGUNGHWA_CAR`` | skyu?<br />[@ChuoSpecialRapid201](https://github.com/ChuoSpecialRapid201), [@opentrain](https://github.com/opentrain)<br />Modified by [@JukjeonWani](https://github.com/JukjeonWani) | [#113](https://github.com/KoreanGRF/KoreanTrainSet/issues/113), [#124](https://github.com/KoreanGRF/KoreanTrainSet/issues/124), [#131](https://github.com/KoreanGRF/KoreanTrainSet/issues/131), [#174](https://github.com/KoreanGRF/KoreanTrainSet/issues/174)<br />modified: [#180](https://github.com/KoreanGRF/KoreanTrainSet/issues/180), [#341](https://github.com/KoreanGRF/KoreanTrainSet/issues/341), [#357](https://github.com/KoreanGRF/KoreanTrainSet/issues/357) |
-| ``passenger_wagon`` | [@telk5093](https://github.telk5093) | |
-| ``SAEMAEUL_CAR`` | skyu?<br />[@ChuoSpecialRapid201](https://github.com/ChuoSpecialRapid201), [@EightonEight](https://github.com/EightonEight)<br />Modified by [@JukjeonWani](https://github.com/JukjeonWani) | [#118](https://github.com/KoreanGRF/KoreanTrainSet/issues/118), [#184](https://github.com/KoreanGRF/KoreanTrainSet/issues/184), [#227](https://github.com/KoreanGRF/KoreanTrainSet/issues/227)<br />modified: [#378](https://github.com/KoreanGRF/KoreanTrainSet/issues/378) |
-| ``SLEEPING_CAR`` | [@ChuoSpecialRapid201](https://github.com/ChuoSpecialRapid201), [@opentrain](https://github.com/opentrain), [@EightonEight](https://github.com/EightonEight) | [#123](https://github.com/KoreanGRF/KoreanTrainSet/issues/123), [#220](https://github.com/KoreanGRF/KoreanTrainSet/issues/220), [#421](https://github.com/KoreanGRF/KoreanTrainSet/pull/421) |
-| ``STAKE_CAR`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@kimgas](https://github.com/kimgas), [@EightonEight](https://github.com/EightonEight), [@SerpensNebula](https://github.com/SerpensNebula) | <https://cafe.naver.com/ottd/15106><br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``STAKE_CAR_without_stake`` | [@EightonEight](https://github.com/EightonEight)<br />Modified by [@SerpensNebula](https://github.com/SerpensNebula) | [#257](https://github.com/KoreanGRF/KoreanTrainSet/issues/257)<br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_BUBL`` | [@SerpensNebula](https://github.com/SerpensNebula)<br />Modified by [@kiwitreekor](https://github.com/kiwitreekor), [@EightonEight](https://github.com/EightonEight) | [#55](https://github.com/KoreanGRF/KoreanTrainSet/issues/55)<br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_COPR`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight), [@SerpensNebula](https://github.com/SerpensNebula) | <https://cafe.naver.com/ottd/15106><br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_ENSP`` | [@EightonEight](https://github.com/EightonEight)<br />Modified by [@SerpensNebula](https://github.com/SerpensNebula) | [#257](https://github.com/KoreanGRF/KoreanTrainSet/issues/257)<br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_FMSP`` | [@EightonEight](https://github.com/EightonEight)<br />Modified by [@SerpensNebula](https://github.com/SerpensNebula) | [#257](https://github.com/KoreanGRF/KoreanTrainSet/issues/257)<br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_PAPR`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight), [@SerpensNebula](https://github.com/SerpensNebula) | <https://cafe.naver.com/ottd/15106><br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_PIPE`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight), [@SerpensNebula](https://github.com/SerpensNebula) | <https://cafe.naver.com/ottd/15106><br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_STEL`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@kimgas](https://github.com/kimgas), [@EightonEight](https://github.com/EightonEight), [@SerpensNebula](https://github.com/SerpensNebula) | <https://cafe.naver.com/ottd/15106><br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_TYRE`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@telk5093](https://github.com/telk5093), [@EightonEight](https://github.com/EightonEight), [@SerpensNebula](https://github.com/SerpensNebula) | modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_VBOD`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight), [@SerpensNebula](https://github.com/SerpensNebula) | <https://cafe.naver.com/ottd/15106><br />modified: [#157](https://github.com/KoreanGRF/KoreanTrainSet/issues/157), [#403](https://github.com/KoreanGRF/KoreanTrainSet/issues/403) |
-| ``cargo_VEHI`` | 〃 | |
-| ``cargo_WDPR`` | 〃 | |
-| ``cargo_WOOD`` | 〃 | |
-| ``cargo_WOOL`` | 〃 | |
-| ``TANK_CAR`` | [@kiwitreekor](https://github.com/kiwitreekor)<br />Modified by [@EightonEight](https://github.com/EightonEight) | <https://cafe.naver.com/ottd/15106><br />modified: [#372](https://github.com/KoreanGRF/KoreanTrainSet/issues/372) |
-| ``TONGIL_CAR`` | [@SerpensNebula](https://github.com/SerpensNebula) | [#134](https://github.com/KoreanGRF/KoreanTrainSet/issues/134) |
+### railtype
+| Code 			| Author 		| Reference |
+|-----------------------|-----------------------|-----------|
+| ``KR_LIGHTRAIL`` 	| 초저항 		| |
+| ``NARROW_GAUGE`` 	| @SerpensNebula 	| #204 |


### PR DESCRIPTION
문서: 기여자 문서 수정

`contributors_graphic.md`
* 위키의 부연 설명 동기화
* 더 간편하게 수정할 수 있도록 테이블 개선
  - 제작자, 참고 이슈/PR 링크 제거
  - 탭 키 정렬(탭 사이즈 8 기준)
  - 그룹화
* 표준 규격으로 만들어진 그래픽 스프라이트의 제작자, 참고 이슈/PR을 별도로 표시
* 최신 커밋에 맞게 기여 업데이트