### PR TITLE
Update: add missing AXIS wagon support

### DIFF
--- a/ko_train_set.pnml
+++ b/ko_train_set.pnml
@@ -44,6 +44,10 @@ cargotable {
     CCPR, FEAL, FOCA, HWAR, N7__, PPWK, PUMP, RBAR, SEAL, STBL, STBR, STIG, STPP, STSL, STTB, TYCO,
     WELD,
 
+    // AXIS (2.x)
+    ACET, ALO_, NHNO, BIOM, CHRO, COCO, CRAN, C2H4, BAKE, ENUM, FORM, FURN, HYAC, H2__, LFEQ, MEAT,
+    MEOH, NAPH, NICK, OLSD, PHAC, C3H6, RAMT, LATX, SWRP, SGCN, SUAC, TEXT, TIN_, TINP, UREA, YARN,
+
     // Improved Town Industries (based on 2.13)
     WSTE, WDCH, SCPR
 }

--- a/src/wagon/box_car/box_car.pnml
+++ b/src/wagon/box_car/box_car.pnml
@@ -57,7 +57,7 @@ item(FEAT_TRAINS, ko_train_BOX_CAR, 5916) {
                                             LVST, GRAI, PAPR, WHEA, SUGR, CTCD, CMNT, POWR, BOOM, FECR,
                                             FERT, SALT, SAND, SLAG, SASH, GRVL, SULP, WDPR, VENG, VPTS,
                                             WOOL, SCPR, CCPR, FOCA, HWAR, RBAR, SEAL, STBL, STBR, STIG,
-                                            STTB, TYCO, WELD
+                                            STTB, TYCO, WELD, PPAR
                                         ];
         cargo_disallow_refit:           [];
         loading_speed:                  5;

--- a/src/wagon/box_car/box_car.pnml
+++ b/src/wagon/box_car/box_car.pnml
@@ -57,7 +57,7 @@ item(FEAT_TRAINS, ko_train_BOX_CAR, 5916) {
                                             LVST, GRAI, PAPR, WHEA, SUGR, CTCD, CMNT, POWR, BOOM, FECR,
                                             FERT, SALT, SAND, SLAG, SASH, GRVL, SULP, WDPR, VENG, VPTS,
                                             WOOL, SCPR, CCPR, FOCA, HWAR, RBAR, SEAL, STBL, STBR, STIG,
-                                            STTB, TYCO, WELD, PPAR
+                                            STTB, TYCO, WELD, PPAR, NHNO, FURN, SWRP, TEXT, YARN
                                         ];
         cargo_disallow_refit:           [];
         loading_speed:                  5;

--- a/src/wagon/flat_car/flat_car.pnml
+++ b/src/wagon/flat_car/flat_car.pnml
@@ -47,7 +47,7 @@ item(FEAT_TRAINS, ko_train_FLAT_CAR, 5910) {
         cargo_allow_refit:              [
                                             GOOD, VALU, FOOD, BATT, SWET, TOYS, FISH, BOOM, JAVA, GLAS,
                                             POWR, NUTS, MNSP, VPTS, PPWK, PUMP, STBL, STPP, STSL, STTB,
-                                            PPAR
+                                            PPAR, FURN, BAKE, MEAT, SWRP, TEXT, YARN
                                         ];
         cargo_disallow_refit:           [];
         loading_speed:                  5;

--- a/src/wagon/flat_car/flat_car.pnml
+++ b/src/wagon/flat_car/flat_car.pnml
@@ -46,7 +46,8 @@ item(FEAT_TRAINS, ko_train_FLAT_CAR, 5910) {
         non_refittable_cargo_classes:   NO_CARGO_CLASS;
         cargo_allow_refit:              [
                                             GOOD, VALU, FOOD, BATT, SWET, TOYS, FISH, BOOM, JAVA, GLAS,
-                                            POWR, NUTS, MNSP, VPTS, PPWK, PUMP, STBL, STPP, STSL, STTB
+                                            POWR, NUTS, MNSP, VPTS, PPWK, PUMP, STBL, STPP, STSL, STTB,
+                                            PPAR
                                         ];
         cargo_disallow_refit:           [];
         loading_speed:                  5;

--- a/src/wagon/hopper_car/hopper_car.pnml
+++ b/src/wagon/hopper_car/hopper_car.pnml
@@ -49,7 +49,8 @@ item(FEAT_TRAINS, ko_train_HOPPER_CAR, 5911) {
                                             BEAN, CLAY, COAL, CORE, FRUT, GOLD, GRAI, GRVL, IORE, POTA,
                                             LIME, MNO2, PHOS, PORE, RCYC, SALT, SAND, SCMT, SLAG, FERT,
                                             NITR, CMNT, SASH, SGBT, QLME, PLAS, FECR, CBLK, CASS, BDMT,
-                                            PEAT, COKE, KAOL, WSTE, WDCH, FEAL
+                                            PEAT, COKE, KAOL, WSTE, WDCH, FEAL, ALO_, NHNO, BIOM, COCO,
+                                            NICK, OLSD, RAMT, SGCN, TIN_
                                         ];
         cargo_disallow_refit:           [];
         loading_speed:                  5;
@@ -70,12 +71,16 @@ item(FEAT_TRAINS, ko_train_HOPPER_CAR, 5911) {
         SGBT:                           sw_HOPPER_CAR_BEAN_wagon;
         CASS:                           sw_HOPPER_CAR_BEAN_wagon;
         PEAT:                           sw_HOPPER_CAR_BEAN_wagon;
+        OLSD:                           sw_HOPPER_CAR_BEAN_wagon;
         CLAY:                           sw_HOPPER_CAR_CLAY_wagon;
         COAL:                           sw_HOPPER_CAR_COAL_wagon;
         COKE:                           sw_HOPPER_CAR_COAL_wagon;
         CBLK:                           sw_HOPPER_CAR_COAL_wagon;
         CORE:                           sw_HOPPER_CAR_CORE_wagon;
+        COCO:                           sw_HOPPER_CAR_CORE_wagon;
+        RAMT:                           sw_HOPPER_CAR_CORE_wagon;
         FRUT:                           sw_HOPPER_CAR_FRUT_wagon;
+        SGCN:                           sw_HOPPER_CAR_FRUT_wagon;
         GOLD:                           sw_HOPPER_CAR_GOLD_wagon;
         SULP:                           sw_HOPPER_CAR_GOLD_wagon;
         GRAI:                           sw_HOPPER_CAR_GRAI_wagon;
@@ -84,13 +89,18 @@ item(FEAT_TRAINS, ko_train_HOPPER_CAR, 5911) {
         FERT:                           sw_HOPPER_CAR_GRAI_wagon;
         GRVL:                           sw_HOPPER_CAR_GRVL_wagon;
         CMNT:                           sw_HOPPER_CAR_GRVL_wagon;
+        TIN_:                           sw_HOPPER_CAR_GRVL_wagon;
         IORE:                           sw_HOPPER_CAR_IORE_wagon;
+        ALO_:                           sw_HOPPER_CAR_IORE_wagon;
+        CHRO:                           sw_HOPPER_CAR_IORE_wagon;
         LIME:                           sw_HOPPER_CAR_LIME_wagon;
         QLME:                           sw_HOPPER_CAR_LIME_wagon;
         PLAS:                           sw_HOPPER_CAR_LIME_wagon;
+        NHNO:                           sw_HOPPER_CAR_LIME_wagon;
         MNO2:                           sw_HOPPER_CAR_MNO2_wagon;
         FEAL:                           sw_HOPPER_CAR_MNO2_wagon;   //TODO> offer Ferroalloys graphic
         FECR:                           sw_HOPPER_CAR_MNO2_wagon;
+        NICK:                           sw_HOPPER_CAR_MNO2_wagon;
         PHOS:                           sw_HOPPER_CAR_PHOS_wagon;
         PORE:                           sw_HOPPER_CAR_PORE_wagon;
         RCYC:                           sw_HOPPER_CAR_RCYC_wagon;
@@ -102,6 +112,7 @@ item(FEAT_TRAINS, ko_train_HOPPER_CAR, 5911) {
         NITR:                           sw_HOPPER_CAR_SAND_wagon;
         BDMT:                           sw_HOPPER_CAR_SAND_wagon;
         SCMT:                           sw_HOPPER_CAR_SCMT_wagon;
+        BIOM:                           sw_HOPPER_CAR_SCMT_wagon;
         SLAG:                           sw_HOPPER_CAR_SLAG_wagon;
         default:                        sw_HOPPER_CAR_wagon;
         purchase:                       sw_HOPPER_CAR_purchase;

--- a/src/wagon/stake_car/stake_car.pnml
+++ b/src/wagon/stake_car/stake_car.pnml
@@ -47,7 +47,8 @@ item(FEAT_TRAINS, ko_train_STAKE_CAR, 5914) {
         cargo_allow_refit:              [
                                             BUBL, COPR, ENSP, FMSP, PAPR, PIPE, STSE, STEL, VPTS, VENG,
                                             VBOD, VEHI, WDPR, WOOD, WOOL, FICR, STAL, ALUM, STCB, CSTI,
-                                            IRON, STST, STSH, STWR, ZINC, TYRE, METL, SCPR
+                                            IRON, STST, STSH, STWR, ZINC, TYRE, METL, SCPR, CRAN, LFEQ,
+                                            TINP
                                         ];
         cargo_disallow_refit:           [];
         loading_speed:                  5;
@@ -66,6 +67,8 @@ item(FEAT_TRAINS, ko_train_STAKE_CAR, 5914) {
         BUBL:                           sw_STAKE_CAR_BUBL_wagon;
         COPR:                           sw_STAKE_CAR_COPR_wagon;
         ENSP:                           sw_STAKE_CAR_ENSP_wagon;
+        CRAN:                           sw_STAKE_CAR_ENSP_wagon;
+        LFEQ:                           sw_STAKE_CAR_ENSP_wagon;
         FMSP:                           sw_STAKE_CAR_FMSP_wagon;
         PAPR:                           sw_STAKE_CAR_PAPR_wagon;
         PIPE:                           sw_STAKE_CAR_PIPE_wagon;
@@ -80,6 +83,7 @@ item(FEAT_TRAINS, ko_train_STAKE_CAR, 5914) {
         STSH:                           sw_STAKE_CAR_STEL_wagon;
         STWR:                           sw_STAKE_CAR_STEL_wagon;
         METL:                           sw_STAKE_CAR_STEL_wagon;
+        TINP:                           sw_STAKE_CAR_STEL_wagon;
         TYRE:                           sw_STAKE_CAR_TYRE_wagon;
         ZINC:                           sw_STAKE_CAR_STEL_wagon;
         VENG:                           sw_STAKE_CAR_STEL_wagon;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c584645d-62df-47f7-ae81-3ff66d1eb54c)

Plastic Parts defined at: https://github.com/EmperorJake/AXIS/blob/master/src/cargos/plastic_parts.py