### PR TITLE
Change: Livery naming consistency /  도색 명칭 일관성 유지 수정

### DIFF
--- a/lang/korean.lng
+++ b/lang/korean.lng
@@ -158,7 +158,7 @@ STR_REFIT_LIVERY_BIDULGI_1960                              : (보통 / 1962~1974
 STR_REFIT_LIVERY_BIDULGI_1970                              : (보통 / 1969~1983년 도색)
 STR_REFIT_LIVERY_BIDULGI_1980                              : (비둘기호 / 1984~1994년 도색)
 STR_REFIT_LIVERY_BIDULGI_1990                              : (비둘기호 / 1994~2000년 도색)
-STR_REFIT_LIVERY_BIDULGI_BAGGAGE_CAR                       : (비둘기호 수화물차)
+STR_REFIT_LIVERY_BIDULGI_BAGGAGE_CAR                       : (비둘기호 도색)
 STR_REFIT_LIVERY_BIDULGI_TONGIL_GREEN_1980                 : (통일호 / 1980년대 도색)
 STR_REFIT_LIVERY_BIDULGI_TONGIL_GREEN_1990                 : (통일호 / 1990년대 도색)
 STR_REFIT_LIVERY_BIDULGI_MUGUNGHWA                         : (무궁화호 / 1986~1988년 도색)


### PR DESCRIPTION
#491 에서 언급된 도색 명칭을
(열차 등급 - 좌석 등급) / 운행 시기) 체계로 통일화 하여 일관성 있게 수정하였습니다.

예시) `(비둘기호 / 1984~1994년 도색)` `(새마을호 장대형 특실 / 2005~2020년 도색)`

병합된다면 발전차, 침대차 등 다른 부분도 일관성 있게 수정하겠습니다.

